### PR TITLE
Fix software classification

### DIFF
--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -50,6 +50,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 
 * [Mailpile](https://mailpile.is)
 * [Roundcube](https://roundcube.net/)
+* [Pixelated](https://pixelated-project.org)
 
 ## Webmail Provider with Browser Plugins
 The following webmail providers support email encryption via the OpenPGP standard using [Mailvelope](/software/mailvelope/).

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -2,7 +2,7 @@
 title: "Email Encryption"
 permalink: /software/
 excerpt: "Email Encryption"
-modified: 2017-09-27T09:00:00-00:00
+modified: 2017-11-25T09:00:00-00:00
 ---
 
 {% include base_path %}

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -49,6 +49,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 ## Webmail software with OpenPGP support
 
 * [Mailpile](https://mailpile.is)
+* [Roundcube](https://roundcube.net/)
 
 ## Webmail Provider with Browser Plugins
 The following webmail providers support email encryption via the OpenPGP standard using [Mailvelope](/software/mailvelope/).

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -68,6 +68,10 @@ While these are easier to set up and provide basic security guarantees with Open
 * [Mailfence](https://www.mailfence.com/)
 * [ProtonMail](https://protonmail.com/)
 
+## Mailing list software
+
+* [Schleuder encrypted mailinglist](https://schleuder2.nadir.org)
+
 ## Project Missing?
 If a project is missing and you would like it included, please open a pull request at [github.com/OpenPGP/openpgp.github.io](https://github.com/OpenPGP/openpgp.github.io).
 Please note that we only include published, working software, which implements the standard.

--- a/_software/01-software.md
+++ b/_software/01-software.md
@@ -46,6 +46,10 @@ No security audits have been done by us and, thus, we cannot provide any securit
 ## Browser Plugins
 * [Mailvelope](/software/mailvelope/)
 
+## Webmail software with OpenPGP support
+
+* [Mailpile](https://mailpile.is)
+
 ## Webmail Provider with Browser Plugins
 The following webmail providers support email encryption via the OpenPGP standard using [Mailvelope](/software/mailvelope/).
 

--- a/_software/02-other.md
+++ b/_software/02-other.md
@@ -13,9 +13,6 @@ All applications on this page implement the OpenPGP standard.
 The authors of this webpage are not actively participating in the development of each of these third-party apps.
 No security audits have been done by us and, thus, we cannot provide any security guarantees.
 
-## Other Projects
-* [Pixelated](https://pixelated-project.org)
-
 ## Keyservers
 * [LEAP](https://leap.se)
 * [Mailvelope Keyserver](https://keys.mailvelope.com)

--- a/_software/02-other.md
+++ b/_software/02-other.md
@@ -14,7 +14,6 @@ The authors of this webpage are not actively participating in the development of
 No security audits have been done by us and, thus, we cannot provide any security guarantees.
 
 ## Other Projects
-* [Mailpile](https://mailpile.is)
 * [Pixelated](https://pixelated-project.org)
 
 ## Keyservers

--- a/_software/02-other.md
+++ b/_software/02-other.md
@@ -2,7 +2,7 @@
 title: "Other"
 permalink: /software/other/
 excerpt: "Other"
-modified: 2016-08-15T15:00:00-00:00
+modified: 2017-11-25T15:00:00-00:00
 ---
 
 {% include base_path %}

--- a/_software/02-other.md
+++ b/_software/02-other.md
@@ -19,9 +19,6 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Nyms](http://nyms.io)
 * [SKS Keyserver](https://sks-keyservers.net)
 
-## Miscellaneous
-* [Schleuder encrypted mailinglist](https://schleuder2.nadir.org)
-
 ## Project Missing?
 If a project is missing and you would like it included, please open a pull request at [github.com/OpenPGP/openpgp.github.io](https://github.com/OpenPGP/openpgp.github.io).
 Please note that we only include published, working software, which implements the standard.


### PR DESCRIPTION
It is strange to see "mailpile" in "others" - it is an email client
like others in the "software" list.

Similarly, it doesn't make sense to me that Schleuder is hidden down
into "other" as well, so move it along with the larger group.

An alternative to this would be to rename the "Other" section to
"Server software" which would allow a better regrouping of the
keyserver/webmail/mailing list software under one roof.

What do you think?