### PR TITLE
rename and expand the "other" section to "server"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -28,8 +28,8 @@ software:
     children:
       - title: "Email Encryption"
         url: /software/
-      - title: "Other"
-        url: /software/other/
+      - title: "Server-side services"
+        url: /software/server/
       - title: "Developer Libraries/Tools"
         url: /software/developer/
 

--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -17,6 +17,7 @@ No security audits have been done by us and, thus, we cannot provide any securit
 
 * [Mailpile](https://mailpile.is)
 * [Pixelated](https://pixelated-project.org)
+* [Roundcube](https://roundcube.net/)
 
 ## Keyservers
 
@@ -29,8 +30,10 @@ No security audits have been done by us and, thus, we cannot provide any securit
 ## Mailing list software
 
 * [Schleuder encrypted mailinglist](https://schleuder2.nadir.org)
+* [Mailman 3 PGP plugin](https://pypi.python.org/pypi/mailman-pgp)
 
 ## Project Missing?
+
 If a project is missing and you would like it included, please open a pull request at [github.com/OpenPGP/openpgp.github.io](https://github.com/OpenPGP/openpgp.github.io).
 Please note that we only include published, working software, which implements the standard.
 The software is ordered alphabetically within the sections.

--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -1,8 +1,8 @@
 ---
-title: "Other"
-permalink: /software/other/
-excerpt: "Other"
-modified: 2016-08-15T15:00:00-00:00
+title: "Server"
+permalink: /software/server/
+excerpt: "Server software"
+modified: 2017-11-25T13:35:11-05:00
 ---
 
 {% include base_path %}

--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -19,7 +19,9 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Pixelated](https://pixelated-project.org)
 
 ## Keyservers
-* [LEAP](https://leap.se)
+
+* [Nicknym](https://leap.se/en/docs/design/nicknym), from
+  the [LEAP](https://leap.se/) project
 * [Mailvelope Keyserver](https://keys.mailvelope.com)
 * [Nyms](http://nyms.io)
 * [SKS Keyserver](https://sks-keyservers.net)

--- a/_software/02-server.md
+++ b/_software/02-server.md
@@ -13,7 +13,8 @@ All applications on this page implement the OpenPGP standard.
 The authors of this webpage are not actively participating in the development of each of these third-party apps.
 No security audits have been done by us and, thus, we cannot provide any security guarantees.
 
-## Other Projects
+## Webmail clients
+
 * [Mailpile](https://mailpile.is)
 * [Pixelated](https://pixelated-project.org)
 
@@ -23,7 +24,8 @@ No security audits have been done by us and, thus, we cannot provide any securit
 * [Nyms](http://nyms.io)
 * [SKS Keyserver](https://sks-keyservers.net)
 
-## Miscellaneous
+## Mailing list software
+
 * [Schleuder encrypted mailinglist](https://schleuder2.nadir.org)
 
 ## Project Missing?


### PR DESCRIPTION
"Other" does not mean much: it seems the software there is mostly
targeted at being installed on a server by qualified sysadmins. Make
that clearer by explicitly calling this a "server" section.

We also take the opportunity of adding a few projects like Roundcube
and Mailman-PGP and fix the LEAP documentation.

Closes #13.